### PR TITLE
Fix computed property compile errors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -147,7 +147,7 @@ Use the short version of computed properties if you only need to implement a get
 
 ```swift
 class Example {
-    var age {
+    var age: UInt32 {
         return arc4random()
     }
 }
@@ -157,7 +157,7 @@ to this:
 
 ```swift
 class Example {
-    var age {
+    var age: UInt32 {
         get {
             return arc4random()
         }
@@ -169,7 +169,7 @@ If you add a set or a didSet to the property then you will need to explicitly pr
 
 ```swift
 class Person {
-    var age {
+    var age: UInt32 {
         get {
             return arc4random()
         }

--- a/README.markdown
+++ b/README.markdown
@@ -173,9 +173,9 @@ class Person {
         get {
             return arc4random()
         }
-		didSet {
-			print("Time flies like a banana")
-		}
+        set {
+            print("Time flies like a banana so I'm throwing away your age")
+        }
     }
 }
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -76,11 +76,11 @@ Let the compiler infer self in all cases where it is able to. Areas where self s
 
 ```swift
 struct Example {
-	let name:String
+    let name:String
 
-	init(name:String) {
-		self.name = name
-	}
+    init(name:String) {
+        self.name = name
+    }
 }
 ```
 
@@ -97,8 +97,8 @@ let people = [
 ]
 
 let strings = people.map() {
-	(name:String, age:Int) -> String in
-	return "\(name) is \(age) years old"
+    (name:String, age:Int) -> String in
+    return "\(name) is \(age) years old"
 }
 ```
 
@@ -107,8 +107,8 @@ If at all possible remove the types if the compiler can infer them:
 ```swift
 
 let strings = people.map() {
-	(name, age) in
-	return "\(name) is \(age) years old"
+    (name, age) in
+    return "\(name) is \(age) years old"
 }
 ```
 
@@ -186,8 +186,8 @@ When creating code to convert instances from one type to another use either "to"
 
 ```swift
 struct Mood {
-	func toColor() -> NSColor {
-		return NSColor.blueColor()
+    func toColor() -> NSColor {
+        return NSColor.blueColor()
   }
 }
 ```
@@ -196,9 +196,9 @@ Or `init()` methods:
 
 ```swift
 extension NSColor {
-	convenience init(_ mood:Mood) {
-		super.init(color:NSColor.blueColor)
-	}
+    convenience init(_ mood:Mood) {
+        super.init(color:NSColor.blueColor)
+    }
 }
 ```
 
@@ -206,8 +206,8 @@ While you might be tempted to use a getter, e.g.g:
 
 ```swift
 struct Mood {
-	var color: NSColor {
-		return NSColor.blueColor()
+    var color: NSColor {
+        return NSColor.blueColor()
     }
 }
 ```


### PR DESCRIPTION
1. Added explicit types to computed properties, as required. Though I don’t love `age` being declared a `UInt32`. The alternative would be to make it an `Int` or `UInt` and wrap the `arc4random()` in that. Thoughts?
2. Changed `didSet` to `set` (since you can’t mix `get` and `didSet`)
3. Changed some errant tabs to spaces to be self-consistent