### PR TITLE
Fix markup in code snippet

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -116,8 +116,7 @@ Apple can and will change the parameter types of closures provided by their Swif
 
 You should almost always refrain from specifying the return type. For example this capture list is completely redudant:
 
-```
-swift
+```swift
 dispatch_async(queue) {
     () -> Void in
     print("Fired.")


### PR DESCRIPTION
The language definition for a code snippet needs to be in the first row, otherwise it is interpreted as part of the snippet.