### PR TITLE
Marked the Singleton init method as private

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -226,6 +226,7 @@ Singletons are simple in Swift:
 
 ```swift
 class ControversyManager {
+    private init() {}
     static let sharedInstance = ControversyManager()
 }
 ```


### PR DESCRIPTION
As my friend @alexito4 wrote here http://alejandromp.com/blog/2015/6/28/not-a-singleton/ I think the Singleton should allow to create only **one** instance of it.