### PR TITLE
Minor fixes in the example of Constants

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -134,7 +134,7 @@ struct PhysicsModel {
 
 class Spaceship {
     static let topSpeed = PhysicsModel.speedOfLightInAVacuum
-    var speed: Double
+    var speed: Int? 
 
     func fullSpeedAhead() {
         speed = Spaceship.topSpeed

--- a/README.markdown
+++ b/README.markdown
@@ -129,7 +129,7 @@ Constants used within type definitions should be declared static within a type. 
 
 ```swift
 struct PhysicsModel {
-    static var speedOfLightInAVacuum = 299_792_458
+    static let speedOfLightInAVacuum = 299_792_458
 }
 
 class Spaceship {

--- a/README.markdown
+++ b/README.markdown
@@ -134,7 +134,7 @@ struct PhysicsModel {
 
 class Spaceship {
     static let topSpeed = PhysicsModel.speedOfLightInAVacuum
-    var speed: Int? 
+    var speed: Int?
 
     func fullSpeedAhead() {
         speed = Spaceship.topSpeed


### PR DESCRIPTION

· Define the speed of light in a vacuum as `let` instead of `var`
· Fix the data type in the example to avoid conversions errors from `Int` to `Double` in the assignation done in the method right below 
